### PR TITLE
Added libfmt-dev dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Installing Java 8
 Grabbing Dependencies
 -----------------------
 
-    $ sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso
+    $ sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso libfmt-dev
 
 Initializing Repository
 -----------------------


### PR DESCRIPTION
Fixes a build issue related to missing libfmt headers. Tested on Ubuntu 20.04.1 LTS.

```
system/core/base/include/android-base/format.h:23:10: fatal error: 'fmt/chrono.h' file not found
#include <fmt/chrono.h>
         ^~~~~~~~~~~~~~
1 error generated.
```